### PR TITLE
network interface support queues and ringbuffer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - ecx-*
 env:
-  VERSION: v0.51.0.2
+  VERSION: v0.51.0.3
 
 jobs:
   build_x86:

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -13689,6 +13689,16 @@
        "$ref": "#/definitions/v1.Port"
       }
      },
+     "queues": {
+      "description": "network interface queue",
+      "type": "integer",
+      "format": "int32"
+     },
+     "rxQueueSize": {
+      "description": "The optional rx_queue_size attribute controls the size of virtio ring for each queue.",
+      "type": "integer",
+      "format": "int32"
+     },
      "slirp": {
       "$ref": "#/definitions/v1.InterfaceSlirp"
      },
@@ -13698,6 +13708,11 @@
      "tag": {
       "description": "If specified, the virtual network interface address and its tag will be provided to the guest via config drive",
       "type": "string"
+     },
+     "txQueueSize": {
+      "description": "The optional rx_queue_size attribute controls the size of virtio ring for each queue.",
+      "type": "integer",
+      "format": "int32"
      }
     }
    },

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1069,7 +1069,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		if v, exists := vmi.Annotations[v1.EcxPciPortNumAnnotation]; exists {
 			if num, err := strconv.Atoi(v); err == nil {
 				pciPortNum = num
-			}else{
+			} else {
 				log.Log.Object(vmi).Warningf("Applying virtio pci-root-port num for vmi %s not a valid number", vmi.Name)
 			}
 		}

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -724,9 +724,11 @@ type Interface struct {
 }
 
 type InterfaceDriver struct {
-	Name   string `xml:"name,attr"`
-	Queues *uint  `xml:"queues,attr,omitempty"`
-	IOMMU  string `xml:"iommu,attr,omitempty"`
+	Name        string `xml:"name,attr"`
+	Queues      *uint  `xml:"queues,attr,omitempty"`
+	IOMMU       string `xml:"iommu,attr,omitempty"`
+	TxQueueSize *uint  `xml:"tx_queue_size,attr,omitempty"`
+	RxQueueSize *uint  `xml:"rx_queue_size,attr,omitempty"`
 }
 
 type LinkState struct {

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -5274,6 +5274,13 @@ var CRDsValidation map[string]string = map[string]string{
                                   - port
                                   type: object
                                 type: array
+                              queues:
+                                description: network interface queue
+                                type: integer
+                              rxQueueSize:
+                                description: The optional rx_queue_size attribute
+                                  controls the size of virtio ring for each queue.
+                                type: integer
                               slirp:
                                 type: object
                               sriov:
@@ -5283,6 +5290,10 @@ var CRDsValidation map[string]string = map[string]string{
                                   address and its tag will be provided to the guest
                                   via config drive
                                 type: string
+                              txQueueSize:
+                                description: The optional rx_queue_size attribute
+                                  controls the size of virtio ring for each queue.
+                                type: integer
                             required:
                             - name
                             type: object
@@ -8605,6 +8616,13 @@ var CRDsValidation map[string]string = map[string]string{
                           - port
                           type: object
                         type: array
+                      queues:
+                        description: network interface queue
+                        type: integer
+                      rxQueueSize:
+                        description: The optional rx_queue_size attribute controls
+                          the size of virtio ring for each queue.
+                        type: integer
                       slirp:
                         type: object
                       sriov:
@@ -8613,6 +8631,10 @@ var CRDsValidation map[string]string = map[string]string{
                         description: If specified, the virtual network interface address
                           and its tag will be provided to the guest via config drive
                         type: string
+                      txQueueSize:
+                        description: The optional rx_queue_size attribute controls
+                          the size of virtio ring for each queue.
+                        type: integer
                     required:
                     - name
                     type: object
@@ -10758,6 +10780,13 @@ var CRDsValidation map[string]string = map[string]string{
                           - port
                           type: object
                         type: array
+                      queues:
+                        description: network interface queue
+                        type: integer
+                      rxQueueSize:
+                        description: The optional rx_queue_size attribute controls
+                          the size of virtio ring for each queue.
+                        type: integer
                       slirp:
                         type: object
                       sriov:
@@ -10766,6 +10795,10 @@ var CRDsValidation map[string]string = map[string]string{
                         description: If specified, the virtual network interface address
                           and its tag will be provided to the guest via config drive
                         type: string
+                      txQueueSize:
+                        description: The optional rx_queue_size attribute controls
+                          the size of virtio ring for each queue.
+                        type: integer
                     required:
                     - name
                     type: object
@@ -12875,6 +12908,13 @@ var CRDsValidation map[string]string = map[string]string{
                                   - port
                                   type: object
                                 type: array
+                              queues:
+                                description: network interface queue
+                                type: integer
+                              rxQueueSize:
+                                description: The optional rx_queue_size attribute
+                                  controls the size of virtio ring for each queue.
+                                type: integer
                               slirp:
                                 type: object
                               sriov:
@@ -12884,6 +12924,10 @@ var CRDsValidation map[string]string = map[string]string{
                                   address and its tag will be provided to the guest
                                   via config drive
                                 type: string
+                              txQueueSize:
+                                description: The optional rx_queue_size attribute
+                                  controls the size of virtio ring for each queue.
+                                type: integer
                             required:
                             - name
                             type: object
@@ -16538,6 +16582,14 @@ var CRDsValidation map[string]string = map[string]string{
                                           - port
                                           type: object
                                         type: array
+                                      queues:
+                                        description: network interface queue
+                                        type: integer
+                                      rxQueueSize:
+                                        description: The optional rx_queue_size attribute
+                                          controls the size of virtio ring for each
+                                          queue.
+                                        type: integer
                                       slirp:
                                         type: object
                                       sriov:
@@ -16547,6 +16599,11 @@ var CRDsValidation map[string]string = map[string]string{
                                           interface address and its tag will be provided
                                           to the guest via config drive
                                         type: string
+                                      txQueueSize:
+                                        description: The optional rx_queue_size attribute
+                                          controls the size of virtio ring for each
+                                          queue.
+                                        type: integer
                                     required:
                                     - name
                                     type: object
@@ -20574,6 +20631,14 @@ var CRDsValidation map[string]string = map[string]string{
                                               - port
                                               type: object
                                             type: array
+                                          queues:
+                                            description: network interface queue
+                                            type: integer
+                                          rxQueueSize:
+                                            description: The optional rx_queue_size
+                                              attribute controls the size of virtio
+                                              ring for each queue.
+                                            type: integer
                                           slirp:
                                             type: object
                                           sriov:
@@ -20584,6 +20649,11 @@ var CRDsValidation map[string]string = map[string]string{
                                               will be provided to the guest via config
                                               drive
                                             type: string
+                                          txQueueSize:
+                                            description: The optional rx_queue_size
+                                              attribute controls the size of virtio
+                                              ring for each queue.
+                                            type: integer
                                         required:
                                         - name
                                         type: object

--- a/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
@@ -1817,6 +1817,21 @@ func (in *Interface) DeepCopyInto(out *Interface) {
 		*out = new(DHCPOptions)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Queues != nil {
+		in, out := &in.Queues, &out.Queues
+		*out = new(uint)
+		**out = **in
+	}
+	if in.TxQueueSize != nil {
+		in, out := &in.TxQueueSize, &out.TxQueueSize
+		*out = new(uint)
+		**out = **in
+	}
+	if in.RxQueueSize != nil {
+		in, out := &in.RxQueueSize, &out.RxQueueSize
+		*out = new(uint)
+		**out = **in
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -1170,6 +1170,15 @@ type Interface struct {
 	// If specified, the virtual network interface address and its tag will be provided to the guest via config drive
 	// +optional
 	Tag string `json:"tag,omitempty"`
+	// network interface queue
+	// +optional
+	Queues *uint `json:"queues,omitempty"`
+	// The optional rx_queue_size attribute controls the size of virtio ring for each queue.
+	// +optional
+	TxQueueSize *uint `json:"txQueueSize,omitempty"`
+	// The optional rx_queue_size attribute controls the size of virtio ring for each queue.
+	// +optional
+	RxQueueSize *uint `json:"rxQueueSize,omitempty"`
 }
 
 // Extra DHCP options to use in the interface.

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -628,6 +628,9 @@ func (Interface) SwaggerDoc() map[string]string {
 		"pciAddress":  "If specified, the virtual network interface will be placed on the guests pci address with the specified PCI address. For example: 0000:81:01.10\n+optional",
 		"dhcpOptions": "If specified the network interface will pass additional DHCP options to the VMI\n+optional",
 		"tag":         "If specified, the virtual network interface address and its tag will be provided to the guest via config drive\n+optional",
+		"queues":      "network interface queue\n+optional",
+		"txQueueSize": "The optional rx_queue_size attribute controls the size of virtio ring for each queue.\n+optional",
+		"rxQueueSize": "The optional rx_queue_size attribute controls the size of virtio ring for each queue.\n+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -16875,6 +16875,27 @@ func schema_kubevirtio_api_core_v1_Interface(ref common.ReferenceCallback) commo
 							Format:      "",
 						},
 					},
+					"queues": {
+						SchemaProps: spec.SchemaProps{
+							Description: "network interface queue",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"txQueueSize": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The optional rx_queue_size attribute controls the size of virtio ring for each queue.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"rxQueueSize": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The optional rx_queue_size attribute controls the size of virtio ring for each queue.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 				},
 				Required: []string{"name"},
 			},


### PR DESCRIPTION
What this PR does / why we need it:
VirtualMachine interface support queues、tx_queue_size and rx_queue_size configuration.

Release note:
NONE